### PR TITLE
avoid compilation errors on OSX(tiles solver)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,14 @@ CXXFLAGS:=$(FLAGS) -std=c++0x
 
 CFLAGS:=$(FLAGS) -std=c99
 
-LDFLAGS:=$(FLAGS) -std=c++0x -lrt
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
+LIB_RT_UNLESS_OSX := ""
+else
+LIB_RT_UNLESS_OSX := "-lrt"
+endif
+
+LDFLAGS:=$(FLAGS) -std=c++0x $(LIB_RT_UNLESS_OSX)
 
 EVERYTHING:=
 

--- a/search/anyprof/profile.cc
+++ b/search/anyprof/profile.cc
@@ -3,6 +3,7 @@
 #include "profile.hpp"
 #include "../../utils/utils.hpp"
 #include <limits>
+#include <errno.h>
 
 AnytimeProfile::AnytimeProfile(unsigned int cb, unsigned int tb,
 		const std::vector<SolutionStream> &stream) {

--- a/search/closedlist.hpp
+++ b/search/closedlist.hpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <typeinfo>
 #include <cstring>
+#include <string>
 
 void dfpair(FILE *, const char *key, const char *fmt, ...);	// utils.hpp
 

--- a/search/lsslrtastar.hpp
+++ b/search/lsslrtastar.hpp
@@ -185,10 +185,12 @@ public:
 		onestep(false),
 		weight(1.0) {
 
+#ifndef __MACH__
 		// ENOENT means that the cpu times reported are bogus.
 		clockid_t id;
 		if (clock_getcpuclockid(0, &id) == ENOENT)
 			fatal("Bad CPU timers");
+#endif
 
 		for (int i = 0; i < argc; i++) {
 			if (strcmp(argv[i], "-onestep") == 0)

--- a/tiles/Make.inc
+++ b/tiles/Make.inc
@@ -17,6 +17,13 @@ TILESSRC:=\
 
 CLEAN+=$(TILESSRC:.cc=.o)
 
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
+STATIC_UNLESS_OSX := ""
+else
+STATIC_UNLESS_OSX := "-static"
+endif
+
 tiles/%md_solver:\
 	tiles/main_mdist.d\
 	$(TILESSRC)\
@@ -25,7 +32,7 @@ tiles/%md_solver:\
 	structs/structs.a\
 	search/search.a
 	@echo $@
-	@$(CXX) -static $(TILESSRC)\
+	@$(CXX) $(STATIC_UNLESS_OSX) $(TILESSRC)\
 		tiles/main_mdist.cc\
 		utils/utils.a\
 		structs/structs.a\

--- a/tiles/generator.cc
+++ b/tiles/generator.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstring>
 #include <cstdio>
+#include <errno.h>
 
 using namespace std;
 

--- a/tiles/mdist.cc
+++ b/tiles/mdist.cc
@@ -25,11 +25,12 @@ TilesMdist::State TilesMdist::initialstate() {
 
 void TilesMdist::initmd() {
 	for (unsigned int t = 1; t < Ntiles; t++) {
-		unsigned int row = goalpos[t] / Width;
-		unsigned int col = goalpos[t] % Width;
+		int row = goalpos[t] / Width;
+		int col = goalpos[t] % Width;
 		for (int i = 0; i < Ntiles; i++) {
-			unsigned int r = i / Width;
-			unsigned int c = i % Width;
+			int r = i / Width;
+			int c = i % Width;
+
 			md[t][i] = abs(r - row) + abs(c - col);
 		}
 	}

--- a/utils/time.cc
+++ b/utils/time.cc
@@ -4,6 +4,11 @@
 #include <ctime>
 #include <cerrno>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #include "../utils/utils.hpp"
 
 double walltime() {
@@ -17,7 +22,19 @@ double walltime() {
 
 double cputime() {
 	struct timespec ts;
+
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	ts.tv_sec = mts.tv_sec;
+	ts.tv_nsec = mts.tv_nsec;
+#else
 	if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) < 0)
 		fatalx(errno, "clock_gettime failed");
+#endif
+
 	return ts.tv_sec + (double) ts.tv_nsec/(double) 1e9;
 }


### PR DESCRIPTION
I wanted to try tiles solvers on OSX, however, I saw some errors during build through "make tiles".

I haven't understood the codes yet, but I tried fixing compilation error at least on my environment(OSX10.11.6), and I want to share it with other OSX users.

I will use Linux environment for serious benchmarks, but it is excellent to run this solver in my usual environment, and hence if you have any suggestions for my way of fixes in this commit, I would appreciate if you could tell me about that.